### PR TITLE
Bind fs.defaultFS to host in order to enable access to hdfs from outside

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,6 +9,9 @@ rm /tmp/*.pid
 # installing libraries if any - (resource urls added comma separated to the ACP system variable)
 cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; curl -LO $cp ; done; cd -
 
+# altering the core-site configuration
+sed -i.bak  s/localhost/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/core-site.xml
+
 service sshd start
 $HADOOP_PREFIX/sbin/start-dfs.sh
 $HADOOP_PREFIX/sbin/start-yarn.sh


### PR DESCRIPTION
If hdfs is bound to localhost then access from external tools (e.g. Spark) is not possible
