### PR TITLE
HWXUP-5 use a pam patched centos instead of the stock centos 6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # docker build -t sequenceiq/hadoop .
 
-FROM tianon/centos:6.5
+FROM sequenceiq/pam
 MAINTAINER SequenceIQ
 
 USER root


### PR DESCRIPTION
HWXUP-5 use a pam patched centos instead of the stock centos 6.5
