### PR TITLE
HWXUP-3 starting ssh on port 2122 in order to support --net=host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN ls -la /usr/local/hadoop/etc/hadoop/*-env.sh
 # fix the 254 error code
 RUN sed  -i "/^[^#]*UsePAM/ s/.*/#&/"  /etc/ssh/sshd_config
 RUN echo "UsePAM no" >> /etc/ssh/sshd_config
+RUN echo "Port 2122" >> /etc/ssh/sshd_config
 
 RUN service sshd start && $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh && $HADOOP_PREFIX/sbin/start-dfs.sh && $HADOOP_PREFIX/bin/hdfs dfs -mkdir -p /user/root
 RUN service sshd start && $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh && $HADOOP_PREFIX/sbin/start-dfs.sh && $HADOOP_PREFIX/bin/hdfs dfs -put $HADOOP_PREFIX/etc/hadoop/ input

--- a/ssh_config
+++ b/ssh_config
@@ -2,3 +2,4 @@ Host *
   UserKnownHostsFile /dev/null
   StrictHostKeyChecking no
   LogLevel quiet
+  Port 2122


### PR DESCRIPTION
This fix is required to avoid mixing the ssh ports of host and container, since in case of -net=host the container tried to start sshd on port 22 which lead to a hard to debug errors. The container's sshd port has been moved to 2122.
