### PR TITLE
work around rpmdb checksum error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ MAINTAINER SequenceIQ
 USER root
 
 # install dev tools
-RUN yum install -y curl which tar sudo openssh-server openssh-clients rsync
+RUN yum clean all; \
+    rpm --rebuilddb; \
+    yum install -y curl which tar sudo openssh-server openssh-clients rsync
 # update libselinux. see https://github.com/sequenceiq/hadoop-docker/issues/14
 RUN yum update -y libselinux
 


### PR DESCRIPTION
I was seeing 

    Rpmdb checksum is invalid: dCDPT(pkg checksums): tcp_wrappers-libs.x86_64 0:7.6-57.el6 - u

on build - the PR fixes that.
For your consideration.
