### PR TITLE
Link to canonical bintray repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bin/hdfs dfs -cat output/*
 
 ## Hadoop native libraries, build, Bintray, etc
 
-The Hadoop build process is no easy task - requires lots of libraries and their right version, protobuf, etc and takes some time - we have simplified all these, made the build and released a 64b version of Hadoop nativelibs on this [Bintray repo](https://bintray.com/sequenceiq/sequenceiq-bin/hadoop-native-64bit/2.7.1/view/files). Enjoy.
+The Hadoop build process is no easy task - requires lots of libraries and their right version, protobuf, etc and takes some time - we have simplified all these, made the build and released a 64b version of Hadoop nativelibs on this [Bintray repo](https://bintray.com/sequenceiq/sequenceiq-bin/hadoop-native-64bit). Enjoy.
 
 ## Automate everything
 


### PR DESCRIPTION
Version 2.7.1 doesn't exist on bintray so the link 404's.
To prevent this in the future, simply link to the root of
the project.