### PR TITLE
Start MapReduce JobHistory server and expose IPC port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ CMD ["/etc/bootstrap.sh", "-d"]
 # Hdfs ports
 EXPOSE 50010 50020 50070 50075 50090 8020 9000
 # Mapred ports
-EXPOSE 19888
+EXPOSE 10020 19888
 #Yarn ports
 EXPOSE 8030 8031 8032 8033 8040 8042 8088
 #Other ports

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,6 +16,7 @@ sed s/HOSTNAME/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/core-site.xml.template > 
 service sshd start
 $HADOOP_PREFIX/sbin/start-dfs.sh
 $HADOOP_PREFIX/sbin/start-yarn.sh
+$HADOOP_PREFIX/sbin/mr-jobhistory-daemon.sh start historyserver
 
 if [[ $1 == "-d" ]]; then
   while true; do sleep 1000; done


### PR DESCRIPTION
https://hadoop.apache.org/docs/r2.7.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml

```
mapreduce.jobhistory.address	0.0.0.0:10020	MapReduce JobHistory Server IPC host:port
mapreduce.jobhistory.webapp.address	0.0.0.0:19888	MapReduce JobHistory Server Web UI host:port
```

`19888` was already exposed, but not `10020`.