### PR TITLE
Fix Rpmdb checksum issue and switch to openjdk1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV HADOOP_YARN_HOME /usr/local/hadoop
 ENV HADOOP_CONF_DIR /usr/local/hadoop/etc/hadoop
 ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
 
-RUN sed -i '/^export JAVA_HOME/ s:.*:export JAVA_HOME=/usr/java/default\nexport HADOOP_PREFIX=/usr/local/hadoop\nexport HADOOP_HOME=/usr/local/hadoop\n:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+RUN sed -i '/^export JAVA_HOME/ s:.*:export JAVA_HOME=/etc/alternatives/java_sdk\nexport HADOOP_PREFIX=/usr/local/hadoop\nexport HADOOP_HOME=/usr/local/hadoop\n:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 #RUN . $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
 
 
 # java
-RUN yum -y install java-1.8.0-openjdk-devel.x86_64 maven ant && yum clean all
+RUN yum -y install java-1.8.0-openjdk-devel.x86_64 && yum clean all
 COPY java_env.sh /etc/profile.d/java_env.sh
 
 # download native support

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ USER root
 # install dev tools
 RUN yum clean all; \
     rpm --rebuilddb; \
-    yum install -y curl which tar sudo openssh-server openssh-clients rsync
+    yum install -y yum-plugin-ovl curl which tar sudo openssh-server openssh-clients rsync
 # update libselinux. see https://github.com/sequenceiq/hadoop-docker/issues/14
 RUN yum update -y libselinux
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,8 @@ RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
 
 
 # java
-RUN curl -LO 'http://download.oracle.com/otn-pub/java/jdk/7u71-b14/jdk-7u71-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie'
-RUN rpm -i jdk-7u71-linux-x64.rpm
-RUN rm jdk-7u71-linux-x64.rpm
-
-ENV JAVA_HOME /usr/java/default
-ENV PATH $PATH:$JAVA_HOME/bin
-RUN rm /usr/bin/java && ln -s $JAVA_HOME/bin/java /usr/bin/java
+RUN yum -y install java-1.8.0-openjdk-devel.x86_64 maven ant && yum clean all
+COPY java_env.sh /etc/profile.d/java_env.sh
 
 # download native support
 RUN mkdir -p /tmp/native

--- a/java_env.sh
+++ b/java_env.sh
@@ -1,0 +1,2 @@
+export JAVA_HOME=/etc/alternatives/java_sdk
+export PATH=${JAVA_HOME}/bin:${PATH}


### PR DESCRIPTION
This PR fixes two issues:
1. https://github.com/sequenceiq/hadoop-docker/issues/62
2. invalid Oracle JDK download link, by switching to openjdk1.8

Tests:
1. successfully built on Docker hub: https://hub.docker.com/r/ouyi/hadoop-docker/builds/bz9fqzycmzmcntuhvz8mnv7/
2. successfully ran example MR program `bin/hadoop jar share/hadoop/mapreduce/hadoop-mapreduce-examples-2.7.1.jar grep input output 'dfs[a-z.]+'`